### PR TITLE
feat: M.E.Doc license search, aggregate view & React Router

### DIFF
--- a/certs-view-client/src/components/SearchAggregate.jsx
+++ b/certs-view-client/src/components/SearchAggregate.jsx
@@ -65,7 +65,10 @@ function extractFormsSet(licenses) {
   if (lower.includes('(єдина)') || lower.includes('(єдиний)')) return 'Єдиний комплект';
   if (lower.includes('(стандарт'))                             return 'Стандартний комплект';
   const m = name.match(/\(([^)]+)\)/);
-  return m ? m[1] : null;
+  if (m) return m[1];
+
+  // Plain "Звітніcть" / "Звітність" without qualifier = Повний комплект
+  return 'Повний комплект';
 }
 
 // ── Aggregate modules for a group (deduped by name, keep latest end_date) ────
@@ -93,7 +96,7 @@ function getModuleStats(licenses) {
   const active      = modules.filter(m => isActive(m.end_date)).length;
   const expiringSoon = modules.filter(m => isExpiringSoon(m.end_date)).length;
   const lapsed      = modules.filter(m =>
-    !isActive(m.end_date) && m.end_date && new Date(m.end_date) >= ONE_YEAR_AGO
+    !isActive(m.end_date) && m.end_date
   ).length;
   return { active, expiringSoon, lapsed };
 }
@@ -174,7 +177,7 @@ function LicensesSection({ licenses }) {
     const active       = all.filter(m => isActive(m.end_date)).length;
     const expiringSoon = all.filter(m => isExpiringSoon(m.end_date)).length;
     const lapsed       = all.filter(m =>
-      !isActive(m.end_date) && m.end_date && new Date(m.end_date) >= ONE_YEAR_AGO
+      !isActive(m.end_date) && m.end_date
     ).length;
     return { active, expiringSoon, lapsed };
   }, [licenses]);

--- a/certs-view-client/src/components/SearchMedoc.jsx
+++ b/certs-view-client/src/components/SearchMedoc.jsx
@@ -60,7 +60,10 @@ function extractFormsSet(licenses) {
 
   // Fall back to whatever is in parentheses
   const m = name.match(/\(([^)]+)\)/);
-  return m ? m[1] : null;
+  if (m) return m[1];
+
+  // Plain "Звітніcть" / "Звітність" without qualifier = Повний комплект
+  return 'Повний комплект';
 }
 
 // ── Aggregate modules for a type group ───────────────────────────────────────
@@ -83,7 +86,7 @@ function aggregateModules(licenses) {
   for (const [name, end_date] of moduleMap) {
     if (isActive(end_date)) {
       active.push({ name_module: name, end_date });
-    } else if (end_date && new Date(end_date) >= ONE_YEAR_AGO) {
+    } else if (end_date) {
       lapsed.push({ name_module: name, end_date });
     }
   }

--- a/server/src/services/medoc/MedocService.ts
+++ b/server/src/services/medoc/MedocService.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 
 const LIC_TYPE_NAMES: Record<string, string> = {
   '1':  'Локальна версія',
+  '12': 'Локальна версія',
   '13': 'Мережева версія',
   '7':  'SAF-T UA',
 };


### PR DESCRIPTION
## Summary

- **`/medoc_license`** — пошук ліцензій M.E.Doc: XOR-розшифрування, групування по типу, дедуплікація модулів, підсвічування модулів що закінчуються, всі прострочені видимі
- **`/overview`** — зведений вигляд: ліцензії + сертифікати КЕП паралельно, тільки Підписання з діючою датою, статистика по модулях
- **React Router (BrowserRouter)** — чисті URL без `#`, стан фільтрів/сортування в URL
- **Дизайн** — `#32C48D` бренд-колір на всіх сторінках
- **Backend** — `GET /api/medoc/:edrpou`, Express catch-all для SPA
- **Маппінг типів** — `12` Локальна, `13` Мережева, `7` SAF-T UA
- **Комплект бланків** — з модуля Звітність

## Test plan

- [ ] Пошук на `/medoc_license` — таби, активні та прострочені модулі
- [ ] LIC_Type `12` = Локальна версія
- [ ] `/overview` — тільки Підписання з діючою датою
- [ ] URL зберігає параметри після F5
- [ ] F5 на `/certs` не дає 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)